### PR TITLE
Allow to clone UtpContext and UtpSocket.

### DIFF
--- a/src/utp.rs
+++ b/src/utp.rs
@@ -276,6 +276,7 @@ unsafe impl Send for LibUtp {}
 /// The [`UtpContext`] is the core of a UTP application. It sets up the backing UDP socket and provides
 /// methods for initiating and accepting connections.
 ///
+#[derive(Clone)]
 pub struct UtpContext {
     // libutp is not thread safe, so only one thread at a time can access the underlying utp_context
     libutp: Arc<Mutex<LibUtp>>,
@@ -575,6 +576,7 @@ impl QueuedUtpSocket {
 ///
 /// Writing to and reading from a [`UtpSocket`] is done using the [`AsyncWrite`] and [`AsyncRead`] traits respectively.
 ///
+#[derive(Clone)]
 pub struct UtpSocket {
     addr: SocketAddr,
     libutp: Arc<Mutex<LibUtp>>,


### PR DESCRIPTION
Hi, thanks for this crate!

After trying *many* of the half-finished Rust implementations and bindings of UTP in the past days, this is the first one that worked well for me :slightly_smiling_face: 

This PR adds `Clone` to `UtpSocket` and `UtpContext`. As the underlying IO handle is in an `Arc` anyway, I think this does no harm. At least in `async-std`, a `TcpSocket` is `Clone`, so this allows me to use the `UtpSocket` from this crate in a library I'm developing where a `Clone` requirement is present at the moment (the socket is cloned to "split" into  `AsyncRead` and `AsyncWrite` halves).